### PR TITLE
Better radio button usability

### DIFF
--- a/views/projects/index.haml
+++ b/views/projects/index.haml
@@ -22,8 +22,8 @@
 
     = haml :projects
 
-    - unless params[:user] || params[:q] || params[:state]
+    - unless params[:user] || params[:q]
       #pagination
         - (1..@projects.total_pages).each do |page|
-          %a{:href => "?page=#{page}"}= page
+          %a{:href => "?page=#{page}#{params[:state] ? "&amp;state=" + params[:state] : ''}"}= page
 

--- a/views/users/edit.haml
+++ b/views/users/edit.haml
@@ -12,19 +12,23 @@
           %a{:href => "https://github.com/#{project.user}/#{project.name}"}= project.name
           still being maintained?
 
-        %input{:type => 'radio', :name => "projects[#{project.user}][#{project.name}]", :value => 'maintained', :id => "#{project.name}_maintained", :checked => project.state == 'maintained'}
-        %label Yes.
+        %label
+          %input{:type => 'radio', :name => "projects[#{project.user}][#{project.name}]", :value => 'maintained', :id => "#{project.name}_maintained", :checked => project.state == 'maintained'}
+          Yes.
         %br
 
-        %input{:type => 'radio', :name => "projects[#{project.user}][#{project.name}]", :value => 'searching', :id => "#{project.name}_searching", :checked => project.state == 'searching'}
-        %label No, I'm looking for a new maintainer.
+        %label
+          %input{:type => 'radio', :name => "projects[#{project.user}][#{project.name}]", :value => 'searching', :id => "#{project.name}_searching", :checked => project.state == 'searching'}
+          No, I'm looking for a new maintainer.
         %br
 
-        %input{:type => 'radio', :name => "projects[#{project.user}][#{project.name}]", :value => 'abandoned', :id => "#{project.name}_abandoned", :checked => project.state == 'abandoned'}
-        %label No, the project is abandoned.
+        %label
+          %input{:type => 'radio', :name => "projects[#{project.user}][#{project.name}]", :value => 'abandoned', :id => "#{project.name}_abandoned", :checked => project.state == 'abandoned'}
+          No, the project is abandoned.
         %br
 
-        %input{:type => 'radio', :name => "projects[#{project.user}][#{project.name}]", :value => 'hide', :id => "#{project.name}_hide", :checked => !project.visible }
-        %label Don't list this project
+        %label
+          %input{:type => 'radio', :name => "projects[#{project.user}][#{project.name}]", :value => 'hide', :id => "#{project.name}_hide", :checked => !project.visible }
+          Don't list this project
 
     %input{:type => 'submit', :value => 'Submit', :class => 'small button'}


### PR DESCRIPTION
I've wrapped the radio buttons with their related label element. This allows the user to click anywhere in the label to activate the selected option instead of having to click in the small radio button.

The commit message wrongfully says checkbox instead of radio button, I guess next time I should pay a little more attention.
