### PR TITLE
Remove embedded body on click handler

### DIFF
--- a/views/layout.haml
+++ b/views/layout.haml
@@ -6,7 +6,7 @@
   %title
     = "#{@title} - " if @title
     Still Maintained?
-%body{ :onclick => "window.scrollTo(0,1)" }
+%body
   %div{:id => 'container'}
     = yield
 


### PR DESCRIPTION
When editing your projects this causes the page to jump to the top each time you click, forcing you to scroll _a lot_ if you have more than one page of projects to action.
