### PR TITLE
Fix link to github repository.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,4 +1,4 @@
-h1. Still Maintained? "!http://stillmaintained.com/jeffkreeftmeijer/stillmaintained.png!":http://stillmaintained.com/jeffkreeftmeijer/stillmaintained
+h1. Still Maintained? "!http://stillmaintained.com/stillmaintained/stillmaintained.png!":http://stillmaintained.com/stillmaintained/stillmaintained
 
 Finally a place to mark your open source project as abandoned or looking for a new maintainer.
 
@@ -12,7 +12,7 @@ h3. Getting up and running
 
 To get StillMaintained running locally, the first thing you need to do is clone the repository and install the bundle:
 
-bc. $ git clone git://github.com/jeffkreeftmeijer/stillmaintained.git
+bc. $ git clone git://github.com/stillmaintained/stillmaintained.git
 $ cd stillmaintained
 $ bundle install
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,7 +4,7 @@ default_run_options[:pty] = true
 
 set :scm, :git
 set :git_enable_submodules, 1
-set :repository, 'git@github.com:jeffkreeftmeijer/stillmaintained.git'
+set :repository, 'git@github.com:stillmaintained/stillmaintained.git'
 set :branch, 'master'
 set :ssh_options, { :forward_agent => true }
 

--- a/views/error.haml
+++ b/views/error.haml
@@ -2,4 +2,4 @@
   %h1 Woah, something went wrong
   %h2
     :textile
-      We've been notified of the issue, but you can always "report additional information":https://github.com/jeffkreeftmeijer/stillmaintained/issues. Do you want to go back to the "homepage":/?
+      We've been notified of the issue, but you can always "report additional information":https://github.com/stillmaintained/stillmaintained/issues. Do you want to go back to the "homepage":/?

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -10,7 +10,7 @@
   %div{:id => 'container'}
     = yield
 
-  %a{:href => 'http://github.com/jeffkreeftmeijer/stillmaintained', :id => 'forkme'} Fork me on GitHub
+  %a{:href => 'http://github.com/stillmaintained/stillmaintained', :id => 'forkme'} Fork me on GitHub
 
   :javascript
     var woo_settings = {idle_timeout:'300000', domain:'stillmaintained.com'};


### PR DESCRIPTION
Because the repository has been moved to the stillmaintained
organization, links have been updated to point to
stillmaintained/stillmaintained.
