### PR TITLE
Group projects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     airbrake (3.1.14)
       builder
       json
-    backports (3.3.5)
+    backports (3.6.3)
     bson (1.9.2)
     bson_ext (1.9.2)
       bson (~> 1.9.2)

--- a/application.rb
+++ b/application.rb
@@ -103,8 +103,10 @@ class Application < Sinatra::Base
 
   get '/users/:id/edit' do
     @user = User.find(params[:id])
-    @projects = @user.projects
-    @projects_by_owner = @projects.group_by { |project| project.user }
+    @forked_projects = @user.projects.forks
+    @non_forked_projects = @user.projects.no_forks
+    @forked_projects_by_owner = @forked_projects.group_by { |project| project.user }
+    @non_forked_projects_by_owner = @non_forked_projects.group_by { |project| project.user }
     haml :'users/edit'
   end
 

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -17,6 +17,7 @@ class Project
   has_and_belongs_to_many :users
 
   scope :visible, where(:visible => true)
+  scope :forks, where(:fork => true)
   scope :no_forks, where(:fork.ne => true)
 
   scope :search_by_name, lambda { |query|

--- a/views/users/edit.haml
+++ b/views/users/edit.haml
@@ -5,28 +5,34 @@
 
   %form{:action => "/users/#{@user.id}", :method => 'post'}
 
-    %h2 Non-forks
+    %section
+      %h1 Owned by you
 
-    - @non_forked_projects_by_owner[@user.login].each do |project|
-      = partial 'users/_project', locals: {project: project}
+      - @non_forked_projects_by_owner[@user.login].each do |project|
+        = partial 'users/_project', locals: {project: project}
+
     - @user.organizations.each do |organization|
       - if @non_forked_projects_by_owner.has_key? organization
-        %h2
-          Organization
-          %b= organization
-        - @non_forked_projects_by_owner[organization].each do |project|
-          = partial 'users/_project', locals: {project: project}
+        %section
+          %h1
+            Owned by
+            %b= organization
+          - @non_forked_projects_by_owner[organization].each do |project|
+            = partial 'users/_project', locals: {project: project}
 
-    %h2 Forks
+    %section
+      %h1 Fork by you
 
-    - @forked_projects_by_owner[@user.login].each do |project|
-      = partial 'users/_project', locals: {project: project}
+      - @forked_projects_by_owner[@user.login].each do |project|
+        = partial 'users/_project', locals: {project: project}
+
     - @user.organizations.each do |organization|
       - if @forked_projects_by_owner.has_key? organization
-        %h2
-          Organization
-          %b= organization
-        - @forked_projects_by_owner[organization].each do |project|
-          = partial 'users/_project', locals: {project: project}
+        %section
+          %h1
+            Forked by
+            %b= organization
+          - @forked_projects_by_owner[organization].each do |project|
+            = partial 'users/_project', locals: {project: project}
 
     %input{:type => 'submit', :value => 'Submit', :class => 'small button'}

--- a/views/users/edit.haml
+++ b/views/users/edit.haml
@@ -5,14 +5,28 @@
 
   %form{:action => "/users/#{@user.id}", :method => 'post'}
 
-    - @projects_by_owner[@user.login].each do |project|
+    %h2 Non-forks
+
+    - @non_forked_projects_by_owner[@user.login].each do |project|
       = partial 'users/_project', locals: {project: project}
     - @user.organizations.each do |organization|
-      - if @projects_by_owner.has_key? organization
+      - if @non_forked_projects_by_owner.has_key? organization
         %h2
           Organization
           %b= organization
-        - @projects_by_owner[organization].each do |project|
+        - @non_forked_projects_by_owner[organization].each do |project|
+          = partial 'users/_project', locals: {project: project}
+
+    %h2 Forks
+
+    - @forked_projects_by_owner[@user.login].each do |project|
+      = partial 'users/_project', locals: {project: project}
+    - @user.organizations.each do |organization|
+      - if @forked_projects_by_owner.has_key? organization
+        %h2
+          Organization
+          %b= organization
+        - @forked_projects_by_owner[organization].each do |project|
           = partial 'users/_project', locals: {project: project}
 
     %input{:type => 'submit', :value => 'Submit', :class => 'small button'}

--- a/views/users/edit.haml
+++ b/views/users/edit.haml
@@ -5,11 +5,12 @@
 
   %form{:action => "/users/#{@user.id}", :method => 'post'}
 
-    %section
-      %h1 Owned by you
+    - if @non_forked_projects_by_owner[@user.login]
+      %section
+        %h1 Owned by you
 
-      - @non_forked_projects_by_owner[@user.login].each do |project|
-        = partial 'users/_project', locals: {project: project}
+        - @non_forked_projects_by_owner[@user.login].each do |project|
+          = partial 'users/_project', locals: {project: project}
 
     - @user.organizations.each do |organization|
       - if @non_forked_projects_by_owner.has_key? organization
@@ -20,11 +21,12 @@
           - @non_forked_projects_by_owner[organization].each do |project|
             = partial 'users/_project', locals: {project: project}
 
-    %section
-      %h1 Fork by you
+    - if @forked_projects_by_owner[@user.login]
+      %section
+        %h1 Fork by you
 
-      - @forked_projects_by_owner[@user.login].each do |project|
-        = partial 'users/_project', locals: {project: project}
+        - @forked_projects_by_owner[@user.login].each do |project|
+          = partial 'users/_project', locals: {project: project}
 
     - @user.organizations.each do |organization|
       - if @forked_projects_by_owner.has_key? organization


### PR DESCRIPTION
Yak shaving... I have a lot of projects and instead of going thru each one I "saved" time by creating this PR.

This change groups the projects on the edit page into sections for:
- Projects owned by the user
- Projects forked by the user
- Projects owned by an organization where the user is an admin
- Projects forked by an organization where the user is an admin

I didn't mess around w/ styling or behavior (e.g. collapsible sections), but they are grouped into HTML5 section elements so that wouldn't be hard to do.
